### PR TITLE
fix(monorepo-preview-release): use PR files API for changed detection

### DIFF
--- a/actions/monorepo-preview-release/src/core.ts
+++ b/actions/monorepo-preview-release/src/core.ts
@@ -43,7 +43,7 @@ export async function publishPackages(options: Options): Promise<PublishResults>
   }
 
   const allPackages = await getWorkspacesPackages();
-  const changedPackages = await getChangedPackages(octokit, allPackages);
+  const changedPackages = await getChangedPackages(octokit, allPackages, prNumber);
   const packagesToPublish = await getPackagesToPublish(changedPackages, allPackages);
 
   if (!packagesToPublish.length) {

--- a/actions/monorepo-preview-release/src/utils.ts
+++ b/actions/monorepo-preview-release/src/utils.ts
@@ -60,16 +60,15 @@ export async function getWorkspacesPackages(): Promise<Array<Package>> {
   return $`pnpm list -r --json`.json();
 }
 
-export async function getChangedPackages(octokit: Octokit, allPackages: Array<Package>) {
+export async function getChangedPackages(octokit: Octokit, allPackages: Array<Package>, prNumber: number) {
   function getRelativeFolderPath(absPath: string) {
     const relativePath = relative(process.cwd(), absPath);
     return relativePath.length > 0 ? relativePath : null;
   }
 
-  const lastCheckpoint = await getLastCheckpoint(octokit);
-  const changedPaths = (await $`git fetch origin main && git diff --name-only ${lastCheckpoint}`.text()).trim().split("\n");
+  const { owner, repo } = github.context.repo;
+  const changedPaths = await getPrChangedFiles(octokit, owner, repo, prNumber);
 
-  core.debug(`Last checkpoint: ${lastCheckpoint}`);
   core.debug(`Changed paths:\n${changedPaths.join("\n")}`);
 
   const changedPackagesSet = new Set<Package>();
@@ -112,25 +111,26 @@ export async function getPackagesToPublish(changedPackages: Array<Package>, allP
   return packagesToPublish;
 }
 
-export async function getLastCheckpoint(octokit: Octokit) {
-  const defaultCase = "origin/main";
+async function getPrChangedFiles(octokit: Octokit, owner: string, repo: string, prNumber: number) {
+  const files: Array<string> = [];
+  let page = 1;
 
-  try {
-    const { owner, repo } = github.context.repo;
-
-    const searchResponse = await octokit.rest.search.commits({
-      q: `repo:${owner}/${repo} "RELEASING:"`,
-      sort: "committer-date",
-      order: "desc",
-      per_page: 1,
+  while (true) {
+    const response = await octokit.rest.pulls.listFiles({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page: 100,
+      page,
     });
 
-    const lastReleaseCommit = searchResponse?.data?.items?.[0];
+    for (const file of response.data) {
+      files.push(file.filename);
+    }
 
-    core.debug(`Last release commit: ${lastReleaseCommit?.sha ?? "not found"}`);
-
-    return lastReleaseCommit?.sha ?? defaultCase;
-  } catch {
-    return defaultCase;
+    if (response.data.length < 100) break;
+    page++;
   }
+
+  return files;
 }

--- a/actions/monorepo-preview-release/src/utils.ts
+++ b/actions/monorepo-preview-release/src/utils.ts
@@ -114,8 +114,9 @@ export async function getPackagesToPublish(changedPackages: Array<Package>, allP
 async function getPrChangedFiles(octokit: Octokit, owner: string, repo: string, prNumber: number) {
   const files: Array<string> = [];
   let page = 1;
+  const MAX_PAGES = 30;
 
-  while (true) {
+  while (page <= MAX_PAGES) {
     const response = await octokit.rest.pulls.listFiles({
       owner,
       repo,


### PR DESCRIPTION
## Summary
- Replace `git diff` against last `RELEASING:` commit with `octokit.rest.pulls.listFiles()` to detect changed packages
- The previous approach diffed against the last release commit, which included changes from all merged PRs since the last release — not just the current PR
- This caused preview releases to publish all packages instead of only the ones changed in the PR

## Test plan
- [ ] Trigger preview release on a PR that only changes one package and verify only that package is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)