### PR TITLE
feat(monorepo-preview-release): per-package OIDC publish with token fallback

### DIFF
--- a/actions/monorepo-preview-release/README.md
+++ b/actions/monorepo-preview-release/README.md
@@ -9,8 +9,20 @@ This Github action creates a preview release of your package and comments on the
   uses: variableland/gh-actions/actions/monorepo-preview-release@main
   with:
     github_token: ${{ secrets.GITHUB_TOKEN }}
-    auth_token: ${{ secrets.NPM_TOKEN }} # optional
+    npm_token: ${{ secrets.NPM_TOKEN }} # optional, see "Authentication" below
 ```
+
+## Authentication
+
+Three modes, picked automatically based on inputs and the workspace state:
+
+| State                                  | Mode                          | Behavior                                                                                                              |
+| -------------------------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `.npmrc` already in workspace          | `token-only`                  | Publish using the existing `.npmrc`; never adds `--provenance`.                                                       |
+| `npm_token` input provided             | `oidc-with-token-fallback`    | Publish each package with OIDC + `--provenance`; on failure for a given package, fall back to NPM_TOKEN auth without provenance. |
+| Neither                                | `oidc-only`                   | Publish with OIDC + `--provenance`; fail otherwise.                                                                   |
+
+The `oidc-with-token-fallback` mode exists to handle first-time publishes of packages that have no Trusted Publisher configured on npm yet — those publishes will land via the token without provenance, while every other package keeps its provenance attestation.
 
 ## Requirements
 
@@ -52,5 +64,5 @@ jobs:
         uses: variableland/gh-actions/actions/monorepo-preview-release@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          auth_token: ${{ secrets.NPM_TOKEN }} # optional
+          npm_token: ${{ secrets.NPM_TOKEN }} # optional, see "Authentication" below
 ```

--- a/actions/monorepo-preview-release/src/core.ts
+++ b/actions/monorepo-preview-release/src/core.ts
@@ -2,7 +2,14 @@ import fs from "node:fs/promises";
 import * as core from "@actions/core";
 import { $ } from "bun";
 import type { Octokit } from "./types.js";
-import { formatError, getChangedPackages, getPackagesToPublish, getWorkspacesPackages, type Package } from "./utils.js";
+import {
+  formatError,
+  getChangedPackages,
+  getPackagesToPublish,
+  getWorkspacesPackages,
+  isUnpublished,
+  type Package,
+} from "./utils.js";
 
 export type PublishResults = Array<{
   packageName: string;
@@ -16,12 +23,41 @@ type Options = {
   npmToken?: string;
 };
 
+enum PublishMode {
+  OIDC_WITH_TOKEN_FALLBACK = "oidc-with-token-fallback",
+  OIDC_ONLY = "oidc-only",
+  TOKEN_ONLY = "token-only",
+}
+
 async function bumpPackage(pkg: Package, preid: string) {
   return (await $`cd ${pkg.path} && pnpm version prerelease --preid="${preid}" --no-git-tag-version`.text()).trim();
 }
 
-async function publishPackage(pkg: Package, tag: string, useOidc: boolean) {
-  await $`cd ${pkg.path} && pnpm publish --tag="${tag}" --no-git-checks ${useOidc ? "--provenance" : ""}`;
+async function publishPackage(pkg: Package, tag: string, mode: PublishMode) {
+  async function publish(pkg: Package, options: { tag: string; provenance?: boolean }) {
+    await $`cd ${pkg.path} && pnpm publish --tag="${options.tag}" --no-git-checks ${options.provenance ? "--provenance" : ""}`;
+  }
+
+  if (mode === PublishMode.TOKEN_ONLY) {
+    await publish(pkg, { tag });
+    return;
+  }
+
+  try {
+    await publish(pkg, { tag, provenance: true });
+  } catch (cause) {
+    if (mode === PublishMode.OIDC_ONLY) throw cause;
+
+    // Only fall back when this is genuinely a first-time publish (the chicken-and-egg
+    // case with OIDC trusted publishing). Other OIDC failures bubble up.
+    if (!(await isUnpublished(pkg))) throw cause;
+
+    core.warning(
+      `First-time publish detected for ${pkg.name}; using NPM_TOKEN auth without provenance ` +
+        `because no Trusted Publisher is configured yet.`,
+    );
+    await publish(pkg, { tag });
+  }
 }
 
 export function getPublishTag(prNumber: number) {
@@ -33,10 +69,15 @@ export async function publishPackages(options: Options): Promise<PublishResults>
 
   const hasNpmRc = await fs.exists(".npmrc");
   const hasNpmToken = !!npmToken;
-  const useOidc = !hasNpmToken && !hasNpmRc;
-  core.debug(`useOidc: ${useOidc}, hasNpmToken: ${hasNpmToken}, hasNpmRc: ${hasNpmRc}`);
 
-  if (!useOidc && !hasNpmRc) {
+  const mode: PublishMode = hasNpmRc
+    ? PublishMode.TOKEN_ONLY
+    : hasNpmToken
+      ? PublishMode.OIDC_WITH_TOKEN_FALLBACK
+      : PublishMode.OIDC_ONLY;
+  core.debug(`mode: ${mode}, hasNpmToken: ${hasNpmToken}, hasNpmRc: ${hasNpmRc}`);
+
+  if (hasNpmToken && !hasNpmRc) {
     // biome-ignore lint/suspicious/noTemplateCurlyInString: Don't interpolate NPM_TOKEN for security reasons
     await fs.writeFile(".npmrc", "//registry.npmjs.org/:_authToken=${NPM_TOKEN}");
     core.debug(`Wrote .npmrc file with NPM_TOKEN template`);
@@ -70,7 +111,7 @@ export async function publishPackages(options: Options): Promise<PublishResults>
     const tag = getPublishTag(prNumber);
 
     for (const pkg of packagesToPublish) {
-      await publishPackage(pkg, tag, useOidc);
+      await publishPackage(pkg, tag, mode);
     }
   } catch (cause) {
     const error = formatError(cause);

--- a/actions/monorepo-preview-release/src/utils.ts
+++ b/actions/monorepo-preview-release/src/utils.ts
@@ -47,7 +47,7 @@ async function getDependenciesPackages(pkg: Package, packages: Array<Package>) {
   return depPackages;
 }
 
-async function isUnpublished(pkg: Package) {
+export async function isUnpublished(pkg: Package) {
   try {
     const response = await $`pnpm view ${pkg.name} --json`.json();
     return !response.name;


### PR DESCRIPTION
## Summary
Replace the global \`useOidc\` flag in the publish loop with a \`PublishMode\` enum, picked once per run from the workspace state:

| State                    | Mode                          | Behavior                                                                                                       |
| ------------------------ | ----------------------------- | -------------------------------------------------------------------------------------------------------------- |
| \`.npmrc\` already present | \`TOKEN_ONLY\`                  | Token-based publish, no provenance. (Pre-existing behavior preserved.)                                         |
| \`npm_token\` input        | \`OIDC_WITH_TOKEN_FALLBACK\`    | OIDC + \`--provenance\` per package; on failure for a single package that's confirmed unpublished, fall back to NPM_TOKEN auth without provenance. |
| Neither                  | \`OIDC_ONLY\`                   | OIDC + \`--provenance\` per package, no fallback.                                                                |

The new \`OIDC_WITH_TOKEN_FALLBACK\` mode solves the chicken-and-egg with [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers): a brand-new package can't publish via OIDC because no Trusted Publisher record exists yet (since the package itself doesn't exist). Previously, the only escape was to pass an \`npm_token\` globally — which made the action drop \`--provenance\` for **every** package, including the established ones that worked fine via OIDC. Now provenance is preserved for each package that publishes successfully via OIDC; only the genuinely-new package(s) take the token path on the very first publish.

The catch is intentionally narrow: it calls \`isUnpublished(pkg)\` (newly exported from \`utils.ts\`) to confirm the package doesn't exist on npm before falling back. Any other OIDC failure (revoked token, version conflict, network error, etc.) bubbles up unchanged.

## Other changes
- Export \`isUnpublished\` from \`utils.ts\`.
- Fix typo in README example: \`auth_token\` → \`npm_token\`.
- Document the three modes in the README.

## Test plan
- [ ] In a consumer repo that uses this action with \`npm_token\`, push a PR that adds a brand-new package: verify (a) the new package publishes without provenance, (b) all other changed packages still publish with provenance.
- [ ] Verify the existing \`OIDC_ONLY\` path (no \`npm_token\`) still works for repos where every package has Trusted Publishing configured.
- [ ] Verify the existing \`TOKEN_ONLY\` path (\`.npmrc\` already present) is unchanged.