### PR TITLE
fix(monorepo-preview-release): exclude private packages from publish pipeline

### DIFF
--- a/actions/monorepo-preview-release/src/utils.ts
+++ b/actions/monorepo-preview-release/src/utils.ts
@@ -57,7 +57,8 @@ async function isUnpublished(pkg: Package) {
 }
 
 export async function getWorkspacesPackages(): Promise<Array<Package>> {
-  return $`pnpm list -r --json`.json();
+  const packages: Array<Package> = await $`pnpm list -r --json`.json();
+  return packages.filter((pkg) => !pkg.private);
 }
 
 export async function getChangedPackages(octokit: Octokit, allPackages: Array<Package>, prNumber: number) {


### PR DESCRIPTION
## Summary

- `getWorkspacesPackages()` now filters out packages with `"private": true` before they enter the publish pipeline
- Prevents the action from attempting to publish internal/tooling packages that are explicitly marked as non-publishable

## Context

`pnpm list -r --json` returns all workspace packages including private ones. Previously the action relied on `pnpm publish` to fail as a gate, which caused CI failures. The fix excludes private packages at the source so they never enter the bump/publish flow.