### PR TITLE
feat(monorepo-preview-release): invoke vland-bot for preview releases

### DIFF
--- a/actions/monorepo-preview-release/action.yml
+++ b/actions/monorepo-preview-release/action.yml
@@ -11,8 +11,8 @@ inputs:
     description: Token for authentication with npm registry
     required: false
 
-  vlandbot_url:
-    description: URL of the vlandbot server
+  vland_bot_url:
+    description: URL of the vland-bot server
     required: false
     default: "https://bot.variable.land"
 
@@ -26,4 +26,4 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         NPM_TOKEN: ${{ inputs.npm_token }}
-        VLANDBOT_URL: ${{ inputs.vlandbot_url }}
+        VLAND_BOT_URL: ${{ inputs.vland_bot_url }}

--- a/actions/monorepo-preview-release/action.yml
+++ b/actions/monorepo-preview-release/action.yml
@@ -11,6 +11,11 @@ inputs:
     description: Token for authentication with npm registry
     required: false
 
+  vlandbot_url:
+    description: URL of the vlandbot server
+    required: false
+    default: "https://bot.variable.land"
+
 runs:
   using: composite
 
@@ -21,3 +26,4 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         NPM_TOKEN: ${{ inputs.npm_token }}
+        VLANDBOT_URL: ${{ inputs.vlandbot_url }}

--- a/actions/monorepo-preview-release/package.json
+++ b/actions/monorepo-preview-release/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
+    "@actions/http-client": "^4.0.1",
     "markdown-table": "^3.0.4"
   }
 }

--- a/actions/monorepo-preview-release/src/index.ts
+++ b/actions/monorepo-preview-release/src/index.ts
@@ -7,7 +7,7 @@ import { publishPackages } from "./core.js";
 try {
   const githubToken = process.env.GITHUB_TOKEN?.trim();
   const npmToken = process.env.NPM_TOKEN?.trim();
-  const vlandbotUrl = process.env.VLANDBOT_URL?.trim();
+  const vlandBotUrl = process.env.VLAND_BOT_URL?.trim();
 
   const prNumber = github.context.payload.pull_request?.number;
   const latestCommitSha = github.context.payload.pull_request?.head?.sha;
@@ -16,8 +16,8 @@ try {
     throw new Error("GITHUB_TOKEN is not set");
   }
 
-  if (!vlandbotUrl) {
-    throw new Error("VLANDBOT_URL is not set");
+  if (!vlandBotUrl) {
+    throw new Error("VLAND_BOT_URL is not set");
   }
 
   if (!prNumber) {
@@ -49,7 +49,7 @@ try {
     maxRetries: 3,
   });
 
-  const response = await http.postJson(`${vlandbotUrl}/v1/github/preview-release`, {
+  const response = await http.postJson(`${vlandBotUrl}/v1/github/preview-release`, {
     owner,
     repo,
     prNumber,
@@ -58,7 +58,7 @@ try {
   });
 
   if (response.statusCode < 200 || response.statusCode >= 300) {
-    throw new Error(`vlandbot responded with ${response.statusCode}: ${JSON.stringify(response.result)}`);
+    throw new Error(`vland-bot responded with ${response.statusCode}: ${JSON.stringify(response.result)}`);
   }
 } catch (error) {
   core.setFailed(error as unknown as Error);

--- a/actions/monorepo-preview-release/src/index.ts
+++ b/actions/monorepo-preview-release/src/index.ts
@@ -42,7 +42,7 @@ try {
 
   const { owner, repo } = github.context.repo;
 
-  const oidcToken = await core.getIDToken("vlandbot");
+  const oidcToken = await core.getIDToken("vland-bot");
 
   const http = new HttpClient("monorepo-preview-release", [new BearerCredentialHandler(oidcToken)], {
     allowRetries: true,

--- a/actions/monorepo-preview-release/src/index.ts
+++ b/actions/monorepo-preview-release/src/index.ts
@@ -1,129 +1,65 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
-import { markdownTable } from "markdown-table";
-import { getPublishTag, type PublishResults, publishPackages } from "./core.js";
+import { HttpClient } from "@actions/http-client";
+import { BearerCredentialHandler } from "@actions/http-client/lib/auth";
+import { publishPackages } from "./core.js";
 
-const COMMENT_TAG = "<!-- preview-release-action -->";
+try {
+  const githubToken = process.env.GITHUB_TOKEN?.trim();
+  const npmToken = process.env.NPM_TOKEN?.trim();
+  const vlandbotUrl = process.env.VLANDBOT_URL?.trim();
 
-type GetMessageOptions = {
-  results: PublishResults;
-  prNumber: number;
-  latestCommitSha: string;
-};
+  const prNumber = github.context.payload.pull_request?.number;
+  const latestCommitSha = github.context.payload.pull_request?.head?.sha;
 
-function getPreviewReleaseMessage(options: GetMessageOptions) {
-  const { results, prNumber, latestCommitSha } = options;
-
-  const firstResult = results[0];
-
-  return [
-    COMMENT_TAG,
-    "### Preview release",
-    "",
-    `Latest commit: ${latestCommitSha}`,
-    "",
-    "Some packages have been released:",
-    markdownTable([
-      ["Package", "Version", "Install"],
-      ...results.map(({ packageName, nextVersion }) => [packageName, nextVersion, `\`${packageName}@${nextVersion}\``]),
-    ]),
-    "",
-    "> [!NOTE]",
-    "> Use the PR number as tag to install any package. For instance:",
-    "> ```",
-    `> pnpm add ${firstResult?.packageName}@${getPublishTag(prNumber)}`,
-    "> ```",
-  ].join("\n");
-}
-
-function getNoPreviewReleaseMessage(options: GetMessageOptions) {
-  const { latestCommitSha } = options;
-
-  return [
-    COMMENT_TAG,
-    "### Preview release",
-    "",
-    `Latest commit: ${latestCommitSha}`,
-    "",
-    "No packages have been released.",
-  ].join("\n");
-}
-
-function getCommentBody(options: GetMessageOptions) {
-  if (!options.results.length) {
-    return getNoPreviewReleaseMessage(options);
+  if (!githubToken) {
+    throw new Error("GITHUB_TOKEN is not set");
   }
 
-  return getPreviewReleaseMessage(options);
-}
-
-export async function main() {
-  try {
-    const githubToken = process.env.GITHUB_TOKEN?.trim();
-    const npmToken = process.env.NPM_TOKEN?.trim();
-    const prNumber = github.context.payload.pull_request?.number;
-    const latestCommitSha = github.context.payload.pull_request?.head?.sha;
-
-    if (!githubToken) {
-      throw new Error("GITHUB_TOKEN is not set");
-    }
-
-    if (!prNumber) {
-      throw new Error("PR number can not be determined");
-    }
-
-    if (!latestCommitSha) {
-      throw new Error("Latest commit SHA can not be determined");
-    }
-
-    core.debug(`PR number: ${prNumber}`);
-    core.debug(`Latest commit SHA: ${latestCommitSha}`);
-
-    const octokit = github.getOctokit(githubToken);
-
-    const results = await publishPackages({
-      octokit,
-      prNumber,
-      latestCommitSha,
-      npmToken,
-    });
-
-    async function getCommentId() {
-      const comment = await octokit.rest.issues.listComments({
-        repo: github.context.repo.repo,
-        owner: github.context.repo.owner,
-        issue_number: Number(prNumber),
-      });
-
-      const existingComment = comment.data.find((c) => c.body?.includes(COMMENT_TAG));
-
-      return existingComment?.id;
-    }
-
-    const commentId = await getCommentId();
-
-    const payload = {
-      repo: github.context.repo.repo,
-      owner: github.context.repo.owner,
-      issue_number: Number(prNumber),
-      body: getCommentBody({
-        results,
-        prNumber,
-        latestCommitSha,
-      }),
-    };
-
-    if (!commentId) {
-      await octokit.rest.issues.createComment(payload);
-    } else {
-      await octokit.rest.issues.updateComment({
-        ...payload,
-        comment_id: commentId,
-      });
-    }
-  } catch (error) {
-    core.setFailed(error as unknown as Error);
+  if (!vlandbotUrl) {
+    throw new Error("VLANDBOT_URL is not set");
   }
-}
 
-main();
+  if (!prNumber) {
+    throw new Error("PR number can not be determined");
+  }
+
+  if (!latestCommitSha) {
+    throw new Error("Latest commit SHA can not be determined");
+  }
+
+  core.debug(`PR number: ${prNumber}`);
+  core.debug(`Latest commit SHA: ${latestCommitSha}`);
+
+  const octokit = github.getOctokit(githubToken);
+
+  const packages = await publishPackages({
+    octokit,
+    prNumber,
+    latestCommitSha,
+    npmToken,
+  });
+
+  const { owner, repo } = github.context.repo;
+
+  const oidcToken = await core.getIDToken("vlandbot");
+
+  const http = new HttpClient("monorepo-preview-release", [new BearerCredentialHandler(oidcToken)], {
+    allowRetries: true,
+    maxRetries: 3,
+  });
+
+  const response = await http.postJson(`${vlandbotUrl}/v1/github/preview-release`, {
+    owner,
+    repo,
+    prNumber,
+    latestCommitSha,
+    packages,
+  });
+
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw new Error(`vlandbot responded with ${response.statusCode}: ${JSON.stringify(response.result)}`);
+  }
+} catch (error) {
+  core.setFailed(error as unknown as Error);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@actions/github':
         specifier: ^6.0.0
         version: 6.0.1
+      '@actions/http-client':
+        specifier: ^4.0.1
+        version: 4.0.1
       markdown-table:
         specifier: ^3.0.4
         version: 3.0.4
@@ -77,6 +80,9 @@ packages:
 
   '@actions/http-client@2.2.3':
     resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
+
+  '@actions/http-client@4.0.1':
+    resolution: {integrity: sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==}
 
   '@actions/io@1.1.3':
     resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
@@ -2159,6 +2165,10 @@ packages:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
+
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
@@ -2190,6 +2200,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -2294,6 +2305,11 @@ snapshots:
     dependencies:
       tunnel: 0.0.6
       undici: 5.29.0
+
+  '@actions/http-client@4.0.1':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 6.25.0
 
   '@actions/io@1.1.3': {}
 
@@ -4777,6 +4793,8 @@ snapshots:
   undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
+
+  undici@6.25.0: {}
 
   unicorn-magic@0.1.0: {}
 


### PR DESCRIPTION
## Summary
- Add support to invoke vland-bot from the `monorepo-preview-release` action after publishing packages
- Align OIDC audience with `vland-bot`
- Rename `vlandbot` references to `vland-bot` for consistency

## Test plan
- [ ] Verify the action publishes packages and posts to the configured `vland_bot_url`
- [ ] Confirm OIDC token is issued with the `vland-bot` audience
- [ ] Confirm `VLAND_BOT_URL` env / `vland_bot_url` input wiring works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)