### PR TITLE
chore: bump actions to Node.js 24 runtime

### DIFF
--- a/.github/workflows/check-action-dist.yml
+++ b/.github/workflows/check-action-dist.yml
@@ -17,10 +17,10 @@ jobs:
       MISE_EXPERIMENTAL: "1"
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🛠️ Setup mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4
         with:
           install: true
           cache: true

--- a/actions/setup-pnpm-bun/action.yml
+++ b/actions/setup-pnpm-bun/action.yml
@@ -7,7 +7,7 @@ runs:
 
   steps:
     - name: 📦 Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         run_install: false
 
@@ -28,7 +28,7 @@ runs:
         echo "ROTATION_KEY=$(/bin/date -u "+%Y%m")" >> $GITHUB_OUTPUT
 
     - name: 🔁 Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-config.outputs.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-cache-${{ steps.cache-rotation.outputs.ROTATION_KEY }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/actions/setup-pnpm/action.yml
+++ b/actions/setup-pnpm/action.yml
@@ -7,7 +7,7 @@ runs:
 
   steps:
     - name: 📦 Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         run_install: false
 
@@ -33,7 +33,7 @@ runs:
         echo "ROTATION_KEY=$(/bin/date -u "+%Y%m")" >> $GITHUB_OUTPUT
 
     - name: 🔁 Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-config.outputs.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-cache-${{ steps.cache-rotation.outputs.ROTATION_KEY }}-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
## Why

GitHub deprecated the Node.js 20 runtime for Actions. Workflows consuming these actions currently emit:

> Warning: Node.js 20 actions are deprecated. [...] Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.

This bumps every action ref running on Node 20 to its Node 24 major.

## Changes

| Ref | Before (Node 20 ⚠️) | After (Node 24 ✅) | Where |
|---|---|---|---|
| `pnpm/action-setup` | `@v4` | `@v6` | `setup-pnpm`, `setup-pnpm-bun` |
| `actions/cache` | `@v4` | `@v5` | `setup-pnpm`, `setup-pnpm-bun` |
| `actions/checkout` | `@v4` | `@v5` | `check-action-dist.yml` |
| `jdx/mise-action` | `@v2` | `@v4` | `check-action-dist.yml` |

Already on Node 24, left untouched: `oven-sh/setup-bun@v2`.

## Notes

- All bumps are runtime-only majors — no input/config changes.
- `actions/cache@v5` requires Actions Runner ≥ 2.327.1, which GitHub-hosted runners already satisfy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)